### PR TITLE
Fix swank:load-file on Gauche

### DIFF
--- a/gauche-swank.sld
+++ b/gauche-swank.sld
@@ -2,7 +2,7 @@
   (export start-swank
           swank:lookup-presented-object
           swank:lookup-presented-object-or-lose)
-  (import (scheme base) (scheme eval) (scheme read) (scheme write) (scheme file) (scheme case-lambda) (scheme process-context) (scheme repl) (scheme char) (scheme cxr)
+  (import (scheme base) (scheme eval) (scheme read) (scheme write) (scheme file) (scheme case-lambda) (scheme process-context) (scheme repl) (scheme load) (scheme char) (scheme cxr)
           (srfi-69)
           (srfi-27)
           (only (gauche hashutil) hash-table-for-each)


### PR DESCRIPTION
Hello. I'm using Gauche with r7rs-swank.

M-x slime-load-file on Emacs replied 'Evaluation aborted on unbound variable: load: .' .

So, I added (import (scheme load)) to gauche-swank.sld .
