### PR TITLE
Fix for gauche 0.9.9

### DIFF
--- a/gauche-swank.sld
+++ b/gauche-swank.sld
@@ -5,9 +5,9 @@
   (import (scheme base) (scheme eval) (scheme read) (scheme write) (scheme file) (scheme case-lambda) (scheme process-context) (scheme repl) (scheme char) (scheme cxr)
           (srfi-69)
           (srfi-27)
-          (only (gauche hashutil) hash-table-for-each)
           (only (gauche base)
                 keyword? keyword->string module-name all-modules module-table module-imports module-precedence-list ref <procedure> class-of
+                hash-table-for-each
                 macroexpand-1 macroexpand-all)
           (only (gauche net) make-server-socket socket-accept socket-input-port socket-output-port)
           (gauche pputil)

--- a/gauche-swank.sld
+++ b/gauche-swank.sld
@@ -9,6 +9,7 @@
                 keyword? keyword->string module-name all-modules module-table module-imports module-precedence-list ref <procedure> class-of
                 hash-table-for-each
                 macroexpand-1 macroexpand-all)
+          (rename (scheme base) (symbol->string scheme:symbol->string))
           (only (gauche net) make-server-socket socket-accept socket-input-port socket-output-port)
           (gauche pputil)
           (only (srfi-13) string-contains string-prefix? string-replace)

--- a/specific/gauche.scm
+++ b/specific/gauche.scm
@@ -29,12 +29,12 @@
                  ": "
                  (map write-to-string (error-object-irritants error))))
 
-(define sts symbol->string)
+;; required for older gauche which treats keywords distinct from symbols
 (define (symbol->string x)
   (cond ((keyword? x)
          (string-append ":" (keyword->string x)))
         ((symbol? x)
-         (sts x))
+         (scheme:symbol->string x))
         (error "not symbol or keyword" x)))
 
 (define ($output-to-repl thunk)


### PR DESCRIPTION
A couple of small fixes that are needed to run gauche-swank with the upcoming Gauche 0.9.9 release.
The patched version should work with 0.9.8 and before as well (At least, gauche-swank starts without errors).
